### PR TITLE
feat(ghostty): hide macOS titlebar for cleaner look

### DIFF
--- a/ghostty.conf
+++ b/ghostty.conf
@@ -48,6 +48,8 @@
 # # Just for example:
 # resize-overlay-duration = 4s 200ms
 
+macos-titlebar-style = hidden
+
 background = "#1c1c1c"
 background-opacity = 0.95
 background-blur = 10


### PR DESCRIPTION
## Summary
- Set `macos-titlebar-style = hidden` in Ghostty config for a cleaner, more minimal window appearance

## Test plan
- [ ] Open Ghostty and verify the titlebar is hidden
- [ ] Confirm window controls (close/minimize/maximize) still work via hover or keyboard shortcuts

🤖 Generated with [Claude Code](https://claude.com/claude-code)